### PR TITLE
修复access_token失效时后,无法通过getUser获取用户信息的问题

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -316,7 +316,7 @@ OAuth.prototype.getUser = function (options, callback) {
         if (err) {
           return callback(err);
         }
-        that._getUser(options, token.access_token, callback);
+        that._getUser(options, token.data.access_token, callback);
       });
     }
   });

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -339,11 +339,13 @@ describe('oauth.js', function () {
 
         muk(api, 'refreshAccessToken', function (refreshToken, callback) {
           var resp = {
-            "access_token":"ACCESS_TOKEN",
-            "expires_in":7200,
-            "refresh_token":"REFRESH_TOKEN",
-            "openid":"OPENID",
-            "scope":"SCOPE"
+            data: {
+              "access_token": "ACCESS_TOKEN",
+              "expires_in": 7200,
+              "refresh_token": "REFRESH_TOKEN",
+              "openid": "OPENID",
+              "scope": "SCOPE"
+            }
           };
           process.nextTick(function () {
             callback(null, resp);


### PR DESCRIPTION
修复access_token失效时后,无法通过getUser获取用户信息的问题