### PR TITLE
Update authorization url

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -142,7 +142,7 @@ OAuth.prototype.getAuthorizeURL = function (redirect, state, scope) {
  * @param {String} scope 作用范围，值为snsapi_login，前者用于弹出，后者用于跳转
  */
 OAuth.prototype.getAuthorizeURLForWebsite = function (redirect, state, scope) {
-  var url = 'https://open.weixin.qq.com/connect/qrconnect';
+  var url = 'https://open.weixin.qq.com/connect/oauth2/authorize';
   var info = {
     appid: this.appid,
     redirect_uri: redirect,


### PR DESCRIPTION
`/qrconnect` no longer works. See [here](http://mp.weixin.qq.com/wiki/17/c0f37d5704f0b64713d5d2c37b468d75.html).
