### PR TITLE
access token 过期考虑网络时延

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -28,11 +28,13 @@ AccessToken.prototype.isValid = function () {
  * 处理token，更新过期时间
  */
 var processToken = function (that, callback) {
+  var create_at = new Date().getTime();
+
   return function (err, data, res) {
     if (err) {
       return callback(err, data);
     }
-    data.create_at = new Date().getTime();
+    data.create_at = create_at;
     // 存储token
     that.saveToken(data.openid, data, function (err) {
       callback(err, new AccessToken(data));

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -83,6 +83,35 @@ describe('oauth.js', function () {
         });
       });
     });
+
+    describe('should not ok', function () {
+      before(function () {
+        muk(urllib, 'request', function (url, args, callback) {
+          var resp = {
+            "access_token":"ACCESS_TOKEN",
+            "expires_in": 0.1,
+            "refresh_token":"REFRESH_TOKEN",
+            "openid":"OPENID",
+            "scope":"SCOPE"
+          };
+
+          setTimeout(function () {
+            callback(null, resp);
+          }, 100);
+        });
+      });
+
+      after(function () {
+        muk.restore();
+      });
+
+      it('should not ok', function (done) {
+        api.getAccessToken('code', function (err, token) {
+          expect(token.isValid()).not.to.be.ok();
+          done();
+        });
+      });
+    });
   });
 
   describe('refreshAccessToken', function () {


### PR DESCRIPTION
由于微信服务器的处理和响应时延，`AccessToken#isValid()` 判定呈假阴性，即返回 `true` 但实际上 `token` 已经过期。在请求前设置 `create_at` 解决这个问题。